### PR TITLE
Insere validação de status no módulo

### DIFF
--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -26,6 +26,9 @@ class ConfigProvider implements ConfigProviderInterface
         PaymentMethod $paymentMethod
     )
     {
+        if (!$data->getModuleGeneralConfig("module_status"))
+            return false;
+
         $this->ccConfig = $ccConfig;
         $this->assetSource = $assetSource;
         $this->helperData = $data;

--- a/Model/Payment/Api.php
+++ b/Model/Payment/Api.php
@@ -9,7 +9,6 @@ use Vindi\Payment\Helper\Data;
 class Api extends \Magento\Framework\Model\AbstractModel
 {
     private $apiKey;
-    private $moduleStatus;
 
     public function __construct(
         Data $helperData,
@@ -18,8 +17,10 @@ class Api extends \Magento\Framework\Model\AbstractModel
         \Magento\Framework\Message\ManagerInterface $messageManager
     )
     {
-        $this->apiKey = $helperData->getModuleGeneralConfig("api_key");
-        $this->moduleStatus = $helperData->getModuleGeneralConfig("module_status");
+        if (!$helperData->getModuleGeneralConfig("module_status"))
+            return false;
+
+        $this->apiKey = $helperData->getModuleGeneralConfig("api_key"); 
         $this->base_path = $helperData->getBaseUrl();
         $this->moduleList = $moduleList;
         $this->logger = $logger;
@@ -27,10 +28,7 @@ class Api extends \Magento\Framework\Model\AbstractModel
     }
 
     public function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
-    {
-        if (!$this->moduleStatus)
-            return false;
-        
+    {        
         $url = $this->base_path . $endpoint;
         $body = json_encode($data);
         $requestId = number_format(microtime(true), 2, '', '');

--- a/Model/Payment/Api.php
+++ b/Model/Payment/Api.php
@@ -9,6 +9,7 @@ use Vindi\Payment\Helper\Data;
 class Api extends \Magento\Framework\Model\AbstractModel
 {
     private $apiKey;
+    private $moduleStatus;
 
     public function __construct(
         Data $helperData,
@@ -18,16 +19,18 @@ class Api extends \Magento\Framework\Model\AbstractModel
     )
     {
         $this->apiKey = $helperData->getModuleGeneralConfig("api_key");
+        $this->moduleStatus = $helperData->getModuleGeneralConfig("module_status");
         $this->base_path = $helperData->getBaseUrl();
-
         $this->moduleList = $moduleList;
         $this->logger = $logger;
         $this->messageManager = $messageManager;
-
     }
 
     public function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
     {
+        if (!$this->moduleStatus)
+            return false;
+        
         $url = $this->base_path . $endpoint;
         $body = json_encode($data);
         $requestId = number_format(microtime(true), 2, '', '');

--- a/Model/Payment/PaymentMethod.php
+++ b/Model/Payment/PaymentMethod.php
@@ -2,6 +2,7 @@
 
 namespace Vindi\Payment\Model\Payment;
 
+use Vindi\Payment\Helper\Data;
 
 class PaymentMethod
 {
@@ -9,8 +10,10 @@ class PaymentMethod
     const CREDIT_CARD = "credit_card";
     const DEBIT_CARD = "debit_card";
 
-    public function __construct(Api $api, \Magento\Payment\Model\CcConfig $ccConfig)
+    public function __construct(Api $api, \Magento\Payment\Model\CcConfig $ccConfig, Data $data)
     {
+        if (!$data->getModuleGeneralConfig("module_status"))
+            return false;
         $this->api = $api;
         $this->ccConfig = $ccConfig;
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -51,7 +51,13 @@
             <resource>Vindi_Payment::config_vindi_payment</resource>
             <group id="general" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label">
                 <label>General</label>
-                <field id="mode" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20"
+                <field id="module_status" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20"
+                       translate="label"
+                       type="select">
+                    <label>Enabled</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="mode" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="30"
                        translate="label"
                        type="select">
                     <label>Mode</label>


### PR DESCRIPTION
## Motivação
Nos testes de QA do Marketplace do Magento, está sendo apresentado um erro quando não existe chave API preenchida;
Isso se dá, pois o módulo em si, não tem um status (ativo/inativo), apenas o método de pagamento.

## Solução Proposta
Inserir a opção de habilitar/desabilitar o módulo nas configurações, e validar o status da mesma antes de realizar as operações.