### PR TITLE
Adiciona compatibilidade com todos os tipos de produtos

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -7,7 +7,7 @@ use Vindi\Payment\Model\Config\Source\Mode;
 
 class Data extends AbstractHelper
 {
-    private $scopeConfig;
+    protected $scopeConfig;
 
     public function __construct(
         \Magento\Framework\App\Helper\Context $context

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -7,7 +7,7 @@ use Vindi\Payment\Model\Config\Source\Mode;
 
 class Data extends AbstractHelper
 {
-    protected $scopeConfig;
+    private $scopeConfig;
 
     public function __construct(
         \Magento\Framework\App\Helper\Context $context


### PR DESCRIPTION
Issue #42 
## Motivação
Foram relatadas falhas ao tentar realizar a compra utilizando produtos que o tipo seja diferente de 'Simples'.
Desse modo, iremos realizar uma validação para garantir a compatibilidade com os tipos de produtos existentes no Magento 2 atualmente.

## Solução Proposta
- Ajustar o comportamento para produtos to tipo **Bundle**, pois estavam sendo cobrados em duplicidade;
- Tratar o código SKU dos produtos antes de enviá-los à Vindi, pois se não tratados geram erros durante a criação da Fatura.