### PR TITLE
Ajusta versão do Magento no user-agent

### DIFF
--- a/Model/Payment/Api.php
+++ b/Model/Payment/Api.php
@@ -49,7 +49,7 @@ class Api extends \Magento\Framework\Model\AbstractModel
             CURLOPT_SSL_VERIFYPEER => true,
             CURLOPT_HEADER => true,
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_USERAGENT => 'Vindi-Magento/' . $this->getVersion(),
+            CURLOPT_USERAGENT => 'Vindi-Magento2/' . $this->getVersion(),
             CURLOPT_SSLVERSION => 'CURL_SSLVERSION_TLSv1_2',
             CURLOPT_USERPWD => $this->apiKey . ':',
             CURLOPT_URL => $url,


### PR DESCRIPTION
## Motivação
O user-agent do Magento está sendo enviado igual ao Magento 1.

## Solução Proposta
Inserir a versão da base (Magento 2) no user-agent para separar as requisições Magento 1 e 2.