### PR TITLE
Corrige o fluxo em compras com suspeita de fraude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Notas das versões
+## [1.2.0 - 19/08/2019](https://github.com/vindi/vindi-magento2/releases/tag/1.2.0)
+- Corrige falha ao salvar as configurações de métodos de pagamento sem informar a chave API
+- Adiciona atribuicão de status padrao após confirmação de pagamento dos pedidos
+- Ajusta envio de descontos, fretes e taxas para a plataforma Vindi
+- Ajusta fluxo de compra em transações com suspeita de fraude
+
 ## [1.1.0 - 15/05/2019](https://github.com/vindi/vindi-magento2/releases/tag/1.1.0)
 - Insere método de pagamento Boleto Bancário
 

--- a/Model/Payment/AbstractMethod.php
+++ b/Model/Payment/AbstractMethod.php
@@ -203,7 +203,7 @@ abstract class AbstractMethod extends \Magento\Payment\Model\Method\AbstractMeth
                 || $body['payment_method_code'] === PaymentMethod::DEBIT_CARD
                 || $bill['status'] === Bill::PAID_STATUS
                 || $bill['status'] === Bill::REVIEW_STATUS
-                || $bill['charges'][0]['status'] === Bill::FRAUD_REVIEW_STATUS
+                || reset($bill['charges'])['status'] === Bill::FRAUD_REVIEW_STATUS
             ) {
                 $order->setVindiBillId($bill['id']);
                 return $bill['id'];

--- a/Model/Payment/Bill.php
+++ b/Model/Payment/Bill.php
@@ -7,7 +7,7 @@ class Bill
     private $api;
     const PAID_STATUS = 'paid';
     const REVIEW_STATUS = 'review';
-    const FRAUD_REVIEW_STATUS = 'review';
+    const FRAUD_REVIEW_STATUS = 'fraud_review';
 
     public function __construct(Api $api)
     {

--- a/Plugin/SetOrderStatusOnPlace.php
+++ b/Plugin/SetOrderStatusOnPlace.php
@@ -24,17 +24,17 @@ class SetOrderStatusOnPlace
         $this->helperData = $helperData;
     }
 
+    /** 
+     * Faz com que os status de pagamento dos pedidos
+     * sejam atualizados exclusivamente via webhooks da Vindi
+     * 
+     * @param Payment $subject, mixed $result
+     *
+     * @return mixed
+     */
     public function afterPlace(Payment $subject, $result)
     {
-        switch ($subject->getMethod()) {
-            case BankSlip::CODE:
-                $this->pendingStatus($subject);
-                break;
-            case Vindi::CODE:
-                $this->completeStatus($subject);
-                break;
-        }
-
+        $this->pendingStatus($subject);
         return $result;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "vindi/vindi-magento2",
     "description": "Módulo de cobrança Vindi para o Magento 2",
     "type": "magento2-module",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": "GPL-3.0",
     "authors": [
         {

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,7 +8,7 @@
                 <allow_installments>0</allow_installments>
                 <title>Vindi</title>
                 <allowspecific>0</allowspecific>
-                <payment_action>authorize_capture</payment_action>
+                <payment_action>authorize</payment_action>
                 <group>offline</group>
             </vindi>
             <vindi_bankslip>


### PR DESCRIPTION
close #53 

## Motivação
- Compras com revisão manual de faturas (na [Vindi])(https://app.vindi.com.br)) estão retornando um status de conclusão para o pedido
Compras com suspeita de fraude não estão sendo interpretadas como rejeitadas 

## Solução Proposta
- Ajustar a nomenclatura do status de suspeita de fraude com o padrão da Vindi
- Tornar as atualizações de status dos pedidos dependentes dos [Webhooks](https://atendimento.vindi.com.br/hc/pt-br/articles/203305800-O-que-s%C3%A3o-e-como-funcionam-os-Webhooks-) Vindi
  - Todos os pedidos partirão do status `pending`
![image](https://user-images.githubusercontent.com/31661772/63192815-594b6a80-c042-11e9-8ae1-3682e7c69136.png)
## 
Caso seja recebido um _ Webhook_ o status do pedido será alterado de acordo com o _Webhook_ em questão:
- `bill_paid`: Irá atualizar o status do pedido para o status (padrão) configurado no módulo:
![image](https://user-images.githubusercontent.com/31661772/63193137-11791300-c043-11e9-8c68-7b66f47f5510.png)

- `charge_rejected`: Irá atualizar o pedido para o status `canceled` (cancelado), **se não houverem novas retentativas programadas na Vindi**.