### PR TITLE
Corrigindo cadastro de telefone no cliente

### DIFF
--- a/Model/Payment/Customer.php
+++ b/Model/Payment/Customer.php
@@ -105,16 +105,6 @@ class Customer
         return false;
     }
 
-    public function findVindiCustomerByEmail($email)
-    {
-        $response = $this->api->request("customers?query=email={$email}", 'GET');
-
-        if ($response && (1 === count($response['customers'])) && isset($response['customers'][0]['id'])) {
-            return $response['customers'][0]['id'];
-        }
-
-        return false;
-    }
 
     public function startsWith($haystack, $needle)
     {

--- a/Model/Payment/Customer.php
+++ b/Model/Payment/Customer.php
@@ -25,10 +25,6 @@ class Customer
             $customerId = $this->findVindiCustomer($customer->getId());
         }
 
-        if ($customerId) {
-            return $customerId;
-        }
-
         $address = [
             'street' => $billing->getStreetLine(1) ?: '',
             'number' => $billing->getStreetLine(2) ?: '',
@@ -48,6 +44,11 @@ class Customer
             'phones' => $this->formatPhone($billing->getTelephone()),
             'address' => $address
         ];
+
+        if ($customerId) {
+            $this->updateCustomer($customerId, $customerVindi);
+            return $customerId;
+        }
 
         $customerId = $this->createCustomer($customerVindi);
 
@@ -95,6 +96,26 @@ class Customer
         return false;
     }
 
+    public function updateCustomer($id, $body)
+    {
+        if ($response = $this->api->request('customers/'.$id, 'PUT', $body)) {
+            return $response['customer']['id'];
+        }
+
+        return false;
+    }
+
+    public function findVindiCustomerByEmail($email)
+    {
+        $response = $this->api->request("customers?query=email={$email}", 'GET');
+
+        if ($response && (1 === count($response['customers'])) && isset($response['customers'][0]['id'])) {
+            return $response['customers'][0]['id'];
+        }
+
+        return false;
+    }
+
     public function startsWith($haystack, $needle)
     {
          $length = strlen($needle);
@@ -125,4 +146,4 @@ class Customer
           'extension' => '' 
         ]] : [];
     }
-    }
+}

--- a/Model/Payment/Customer.php
+++ b/Model/Payment/Customer.php
@@ -95,14 +95,34 @@ class Customer
         return false;
     }
 
+    public function startsWith($haystack, $needle)
+    {
+         $length = strlen($needle);
+         return (substr($haystack, 0, $length) === $needle);
+    }
+
     public function formatPhone($phone)
     {
+        $phone = preg_replace('/^0|\D+/', '', $phone);
+
+        // remove 55 do início caso tenha o código do país
+        if ($this->startsWith($phone, '55') && strlen($phone) > 11) {
+            $phone = preg_replace('/^' . preg_quote('55', '/') . '/', '', $phone);
+        }
+        if ($this->startsWith($phone, '0') && strlen($phone) > 11) {
+            $phone = preg_replace('/^' . preg_quote('0', '/') . '/', '', $phone);
+        }
+
         $digits = strlen('55' . preg_replace('/^0|\D+/', '', $phone));
         $phone_types = [
             12 => 'landline',
             13 => 'mobile',
         ];
 
-        return array_key_exists($digits, $phone_types) ? $phone_types[$digits] : null;
+        return array_key_exists($digits, $phone_types) ? [[
+          'phone_type' => $phone_types[$digits],
+          'number' => '55' . $phone,
+          'extension' => '' 
+        ]] : [];
     }
-}
+    }


### PR DESCRIPTION
O método `formatPhone` possuía os possíveis retornos: "mobile", "landline" ou null; O restante do método de criação enviava esse retorno como valor de `phones` para a API da Vindi, logo registrava o cliente SEM telefone.

O problema de registrar clientes sem telefone é que alguns gateways de pagamento obrigam o cliente a inseri-lo, como o pagar.me. Logo dava erro no pagamento.

Então foi dada a edição do `formatPhone` para retornar o array associativo de telefone que a API da Vindi deve receber, além disso, colocamos algumas edições para suportar formatos distintos de telefone, como:
- telefones já com o código do país
- telefones com 0 antes do DDD
- telefones com código de país E com o 0 antes do DDD

