### PR TITLE
Tratado pedidos de assinatura com retorno da Vindi sem o atributo bill

### DIFF
--- a/Model/Payment/AbstractMethod.php
+++ b/Model/Payment/AbstractMethod.php
@@ -324,12 +324,14 @@ abstract class AbstractMethod extends OriginAbstractMethod
 
         if ($responseData = $this->subscriptionRepository->create($body)) {
             $bill = $responseData['bill'];
+            $subscription = $responseData['subscription'];
             $this->handleBankSplitAdditionalInformation($payment, $body, $bill);
-            if ($this->successfullyPaid($body, $bill)) {
+            if ($this->successfullyPaid($body, $bill, $subscription)) {
                 $this->handleBankSplitAdditionalInformation($payment, $body, $bill);
-                $order->setVindiBillId($bill['id']);
+                $billId = $bill['id'] ?? 0;
+                $order->setVindiBillId($billId);
                 $order->setVindiSubscriptionId($responseData['subscription']['id']);
-                return $bill['id'];
+                return $billId;
             }
 
             $this->subscriptionRepository->deleteAndCancelBills($responseData['subscription']['id']);
@@ -394,11 +396,19 @@ abstract class AbstractMethod extends OriginAbstractMethod
     /**
      * @param array $body
      * @param $bill
-     *
+     * @param array $subscription
      * @return bool
      */
-    private function successfullyPaid(array $body, $bill)
+    private function successfullyPaid(array $body, $bill, array $subscription = [])
     {
+        // nova validação para permitir pedidos com pagamento/fatura pendente
+        if (!$bill) {
+            $billingType = $subscription['billing_trigger_type'] ?? null;
+            if ($billingType != 'day_of_month') {
+                return true;
+            }
+        }
+
         return $this->isValidPaymentMethodCode($body['payment_method_code'])
             || $this->isValidStatus($bill)
             || $this->isWaitingPaymentMethodResponse($bill);
@@ -426,6 +436,8 @@ abstract class AbstractMethod extends OriginAbstractMethod
      */
     protected function isWaitingPaymentMethodResponse($bill)
     {
+        if (!$bill) return false;
+
         return reset($bill['charges'])['last_transaction']['status'] === Bill::WAITING_STATUS;
     }
 


### PR DESCRIPTION
## O que mudou
_Alterado a validação de pedido de assinatura criado na Vindi para permitir pedidos sem o atributo "bill"._

## Motivação
_Pedidos com o tipo de cobrança da assinatura posterior a data atual o eram criados na Vindi mas não no Magento._

## Solução proposta
_Tratar a validação do retorno da chamada "subscriptions" para permitir pedidos onde a fatura ainda não foi criada._

## Como testar
_Criar uma assinatura com o Tipo de Cobrança ("billing_trigger_type") de Início do Período, e Quando ("billing_trigger_day") maior que 0. Após isso tentar realizar um pedido desta assinatura._
