### PR TITLE
Reverte versão do composer.json para 1.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "vindi/vindi-magento2",
     "description": "Módulo de cobrança Vindi para o Magento 2",
     "type": "magento2-module",
-    "version": "1.5.0",
+    "version": "1.4.0",
     "license": "GPL-3.0",
     "authors": [
         {


### PR DESCRIPTION
## O que mudou
Reversão da version do composer.json para a versão 1.4.0. O versionamento para a nova versão acontecerá no lançamento da release.

## Motivação
Vamos fazer o versionamento do composer no lançamento da nova release.