### PR TITLE
Issue #123 - Fixing The attribute set ID is incorrect on module install process

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -98,7 +98,7 @@ class UpgradeData implements UpgradeDataInterface
         }
 
         $entityTypeId = $categorySetup->getEntityTypeId(Product::ENTITY);
-        $attributeSetId = $categorySetup->getAttributeSetId($entityTypeId, self::VINDI_PLANOS);
+        $attributeSetId = $categorySetup->getAttributeSet($entityTypeId, self::VINDI_PLANOS, 'attribute_set_id');
         if ($attributeSetId) {
             $attributeGroupId = $categorySetup->getAttributeGroupId($entityTypeId, $attributeSetId, self::VINDI_PLAN_SETTINGS);
             if ($attributeGroupId) {


### PR DESCRIPTION
## O que mudou
Alteração do método responsável pela busca do attribute set "Vindi Planos" durante o processo de atualização dos dados setup upgrade.

## Motivação
Erro "The attribute set ID is incorrect. Verify the ID and try again" durante a etapa de setup upgrade do processo de instalação do módulo.

Closes: https://github.com/vindi/vindi-magento2/issues/123
## Solução proposta
Alteração do método "getAttributeSetId" para "getAttributeSet" no arquivo "vindi-magento2/Setup/UpgradeData.php". 
No método "getAttributeSet" nativo da plataforma Magento (/vendor/magento/module-eav/Setup/EavSetup.php). É possível buscar o attribute set pelo "name" e setar o valor do retorno desejado, que no caso é o "attribute_set_id". Essa alteração evita o erro "The attribute set ID is incorrect. Verify the ID and try again." que está ocorrendo no método "getAttributeSetId" classe "/vendor/magento/module-eav/Setup/EavSetup.php".

## Como testar
Realize a instalação do módulo na versão 2.0.0 via composer require
Execute o comando bin/magento setup:upgrade
